### PR TITLE
feat(chain-watcher): implement Base chain watcher for USDC transfers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6881,7 +6881,11 @@
       "name": "@stripeonchain/chain-watcher",
       "version": "0.1.0",
       "dependencies": {
-        "@stripeonchain/shared": "*"
+        "@stripeonchain/shared": "*",
+        "pg": "^8.20.0"
+      },
+      "devDependencies": {
+        "@types/pg": "^8.18.0"
       }
     },
     "services/correlator": {

--- a/services/chain-watcher/package.json
+++ b/services/chain-watcher/package.json
@@ -12,6 +12,10 @@
     "clean": "rm -rf dist tsconfig.tsbuildinfo"
   },
   "dependencies": {
-    "@stripeonchain/shared": "*"
+    "@stripeonchain/shared": "*",
+    "pg": "^8.20.0"
+  },
+  "devDependencies": {
+    "@types/pg": "^8.18.0"
   }
 }

--- a/services/chain-watcher/src/__tests__/base-chain-watcher.test.ts
+++ b/services/chain-watcher/src/__tests__/base-chain-watcher.test.ts
@@ -1,0 +1,246 @@
+import { TransferLog } from '@stripeonchain/shared';
+import { BaseChainWatcher } from '../base-chain-watcher';
+import { InMemoryTransactionStore } from '../transaction-store';
+
+const mockConnectionManager = {
+  start: jest.fn().mockResolvedValue(undefined),
+  stop: jest.fn(),
+  mode: 'disconnected',
+  on: jest.fn(),
+  emit: jest.fn(),
+};
+
+jest.mock('../connection-manager', () => ({
+  ConnectionManager: jest.fn().mockImplementation(() => mockConnectionManager),
+}));
+
+describe('BaseChainWatcher', () => {
+  let watcher: BaseChainWatcher;
+  let store: InMemoryTransactionStore;
+  let transferHandler: (log: TransferLog) => void;
+
+  const merchantAddress1 = '0x1234567890123456789012345678901234567890';
+  const merchantAddress2 = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
+  const nonMerchantAddress = '0x9999999999999999999999999999999999999999';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    store = new InMemoryTransactionStore();
+
+    mockConnectionManager.on.mockImplementation((event: string, handler: () => void) => {
+      if (event === 'transfer') {
+        transferHandler = handler;
+      }
+    });
+
+    watcher = new BaseChainWatcher({
+      httpUrl: 'http://localhost:8545',
+      wsUrl: 'ws://localhost:8546',
+      merchantAddresses: [merchantAddress1, merchantAddress2],
+      transactionStore: store,
+    });
+  });
+
+  afterEach(() => {
+    watcher.stop();
+    store.clear();
+  });
+
+  describe('merchant address management', () => {
+    it('initializes with provided merchant addresses', () => {
+      expect(watcher.merchantAddressCount).toBe(2);
+      expect(watcher.hasMerchantAddress(merchantAddress1)).toBe(true);
+      expect(watcher.hasMerchantAddress(merchantAddress2)).toBe(true);
+    });
+
+    it('normalizes addresses to lowercase', () => {
+      expect(watcher.hasMerchantAddress(merchantAddress1.toUpperCase())).toBe(true);
+    });
+
+    it('adds new merchant addresses', () => {
+      const newAddress = '0xnewaddressnewaddressnewaddressnewaddress';
+      watcher.addMerchantAddress(newAddress);
+      expect(watcher.merchantAddressCount).toBe(3);
+      expect(watcher.hasMerchantAddress(newAddress)).toBe(true);
+    });
+
+    it('removes merchant addresses', () => {
+      watcher.removeMerchantAddress(merchantAddress1);
+      expect(watcher.merchantAddressCount).toBe(1);
+      expect(watcher.hasMerchantAddress(merchantAddress1)).toBe(false);
+    });
+  });
+
+  describe('transfer filtering', () => {
+    it('emits merchantTransfer for transfers to merchant addresses', async () => {
+      const merchantTransferSpy = jest.fn();
+      watcher.on('merchantTransfer', merchantTransferSpy);
+
+      await watcher.start();
+
+      const log: TransferLog = {
+        transactionHash: '0xtxhash1',
+        blockNumber: 12345,
+        blockHash: '0xblockhash1',
+        logIndex: 0,
+        from: '0xsender',
+        to: merchantAddress1,
+        value: '0x5f5e100',
+      };
+
+      transferHandler(log);
+
+      expect(merchantTransferSpy).toHaveBeenCalledWith(log);
+      expect(watcher.statistics.transfersDetected).toBe(1);
+      expect(watcher.statistics.transfersFiltered).toBe(0);
+    });
+
+    it('filters out transfers to non-merchant addresses', async () => {
+      const merchantTransferSpy = jest.fn();
+      watcher.on('merchantTransfer', merchantTransferSpy);
+
+      await watcher.start();
+
+      const log: TransferLog = {
+        transactionHash: '0xtxhash2',
+        blockNumber: 12346,
+        blockHash: '0xblockhash2',
+        logIndex: 0,
+        from: '0xsender',
+        to: nonMerchantAddress,
+        value: '0x5f5e100',
+      };
+
+      transferHandler(log);
+
+      expect(merchantTransferSpy).not.toHaveBeenCalled();
+      expect(watcher.statistics.transfersDetected).toBe(1);
+      expect(watcher.statistics.transfersFiltered).toBe(1);
+    });
+
+    it('handles case-insensitive address matching', async () => {
+      const merchantTransferSpy = jest.fn();
+      watcher.on('merchantTransfer', merchantTransferSpy);
+
+      await watcher.start();
+
+      const log: TransferLog = {
+        transactionHash: '0xtxhash3',
+        blockNumber: 12347,
+        blockHash: '0xblockhash3',
+        logIndex: 0,
+        from: '0xsender',
+        to: merchantAddress1.toUpperCase(),
+        value: '0x5f5e100',
+      };
+
+      transferHandler(log);
+
+      expect(merchantTransferSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('transaction storage', () => {
+    it('stores merchant transfers in the transaction store', async () => {
+      const storedSpy = jest.fn();
+      watcher.on('transactionStored', storedSpy);
+
+      await watcher.start();
+
+      const log: TransferLog = {
+        transactionHash: '0xtxhash4',
+        blockNumber: 12348,
+        blockHash: '0xblockhash4',
+        logIndex: 0,
+        from: '0xsenderaddress',
+        to: merchantAddress1,
+        value: '0x5f5e100',
+      };
+
+      transferHandler(log);
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(storedSpy).toHaveBeenCalled();
+      expect(watcher.statistics.transfersStored).toBe(1);
+
+      const transactions = store.getAll();
+      expect(transactions).toHaveLength(1);
+      expect(transactions[0]).toMatchObject({
+        chain: 'base',
+        tx_hash: '0xtxhash4',
+        block_number: 12348,
+        sender_address: '0xsenderaddress',
+        receiver_address: merchantAddress1.toLowerCase(),
+      });
+    });
+
+    it('skips duplicate transactions', async () => {
+      await watcher.start();
+
+      const log: TransferLog = {
+        transactionHash: '0xtxhash5',
+        blockNumber: 12349,
+        blockHash: '0xblockhash5',
+        logIndex: 0,
+        from: '0xsender',
+        to: merchantAddress1,
+        value: '0x5f5e100',
+      };
+
+      transferHandler(log);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      transferHandler(log);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(watcher.statistics.transfersStored).toBe(1);
+      expect(watcher.statistics.duplicatesSkipped).toBe(1);
+
+      const transactions = store.getAll();
+      expect(transactions).toHaveLength(1);
+    });
+  });
+
+  describe('amount parsing', () => {
+    it('correctly parses USDC amounts (6 decimals)', async () => {
+      await watcher.start();
+
+      const log: TransferLog = {
+        transactionHash: '0xtxhash6',
+        blockNumber: 12350,
+        blockHash: '0xblockhash6',
+        logIndex: 0,
+        from: '0xsender',
+        to: merchantAddress1,
+        value: '0x5f5e100',
+      };
+
+      transferHandler(log);
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const transactions = store.getAll();
+      expect(transactions[0].token_amount).toBe('100000000');
+    });
+  });
+
+  describe('lifecycle', () => {
+    it('starts the connection manager', async () => {
+      await watcher.start();
+      expect(mockConnectionManager.start).toHaveBeenCalled();
+    });
+
+    it('stops the connection manager', async () => {
+      await watcher.start();
+      watcher.stop();
+      expect(mockConnectionManager.stop).toHaveBeenCalled();
+    });
+
+    it('does not start twice', async () => {
+      await watcher.start();
+      await watcher.start();
+      expect(mockConnectionManager.start).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/services/chain-watcher/src/__tests__/transaction-store.test.ts
+++ b/services/chain-watcher/src/__tests__/transaction-store.test.ts
@@ -1,0 +1,123 @@
+import { InMemoryTransactionStore, InsertableTransaction } from '../transaction-store';
+
+describe('InMemoryTransactionStore', () => {
+  let store: InMemoryTransactionStore;
+
+  beforeEach(() => {
+    store = new InMemoryTransactionStore();
+  });
+
+  afterEach(() => {
+    store.clear();
+  });
+
+  const createTransaction = (
+    overrides: Partial<InsertableTransaction> = {},
+  ): InsertableTransaction => ({
+    chain: 'base',
+    tx_hash: '0x' + Math.random().toString(16).slice(2),
+    block_number: 12345,
+    block_hash: '0xblockhash',
+    sender_address: '0xsender',
+    receiver_address: '0xreceiver',
+    token_contract: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+    token_amount: '1000000',
+    ...overrides,
+  });
+
+  describe('insertTransaction', () => {
+    it('inserts a new transaction', async () => {
+      const tx = createTransaction({ tx_hash: '0xunique1' });
+
+      await store.insertTransaction(tx);
+
+      const exists = await store.transactionExists('base', '0xunique1');
+      expect(exists).toBe(true);
+    });
+
+    it('does not insert duplicate transactions', async () => {
+      const tx = createTransaction({ tx_hash: '0xduplicate' });
+
+      await store.insertTransaction(tx);
+      await store.insertTransaction(tx);
+
+      const all = store.getAll();
+      expect(all).toHaveLength(1);
+    });
+
+    it('allows same tx_hash on different chains', async () => {
+      const txBase = createTransaction({ chain: 'base', tx_hash: '0xsamehash' });
+      const txEth = createTransaction({ chain: 'ethereum', tx_hash: '0xsamehash' });
+
+      await store.insertTransaction(txBase);
+      await store.insertTransaction(txEth);
+
+      const all = store.getAll();
+      expect(all).toHaveLength(2);
+    });
+  });
+
+  describe('transactionExists', () => {
+    it('returns true for existing transactions', async () => {
+      const tx = createTransaction({ tx_hash: '0xexists' });
+      await store.insertTransaction(tx);
+
+      const exists = await store.transactionExists('base', '0xexists');
+      expect(exists).toBe(true);
+    });
+
+    it('returns false for non-existing transactions', async () => {
+      const exists = await store.transactionExists('base', '0xnonexistent');
+      expect(exists).toBe(false);
+    });
+
+    it('returns false for wrong chain', async () => {
+      const tx = createTransaction({ chain: 'base', tx_hash: '0xwrongchain' });
+      await store.insertTransaction(tx);
+
+      const exists = await store.transactionExists('ethereum', '0xwrongchain');
+      expect(exists).toBe(false);
+    });
+  });
+
+  describe('getAll', () => {
+    it('returns all inserted transactions', async () => {
+      const tx1 = createTransaction({ tx_hash: '0xtx1' });
+      const tx2 = createTransaction({ tx_hash: '0xtx2' });
+
+      await store.insertTransaction(tx1);
+      await store.insertTransaction(tx2);
+
+      const all = store.getAll();
+      expect(all).toHaveLength(2);
+    });
+
+    it('returns empty array when no transactions', () => {
+      const all = store.getAll();
+      expect(all).toHaveLength(0);
+    });
+  });
+
+  describe('clear', () => {
+    it('removes all transactions', async () => {
+      await store.insertTransaction(createTransaction({ tx_hash: '0xtx1' }));
+      await store.insertTransaction(createTransaction({ tx_hash: '0xtx2' }));
+
+      store.clear();
+
+      const all = store.getAll();
+      expect(all).toHaveLength(0);
+    });
+  });
+
+  describe('close', () => {
+    it('clears the store', async () => {
+      await store.insertTransaction(createTransaction({ tx_hash: '0xtx1' }));
+
+      await store.close();
+
+      const all = store.getAll();
+      expect(all).toHaveLength(0);
+    });
+  });
+});

--- a/services/chain-watcher/src/base-chain-watcher.ts
+++ b/services/chain-watcher/src/base-chain-watcher.ts
@@ -1,0 +1,166 @@
+import { EventEmitter } from 'events';
+import { TransferLog, USDC_CONTRACTS } from '@stripeonchain/shared';
+import { ConnectionManager, ConnectionManagerConfig } from './connection-manager';
+import { TransactionStore, InsertableTransaction } from './transaction-store';
+
+export interface BaseChainWatcherConfig {
+  httpUrl: string;
+  wsUrl: string;
+  merchantAddresses: string[];
+  transactionStore?: TransactionStore;
+}
+
+export interface BaseChainWatcherStats {
+  transfersDetected: number;
+  transfersFiltered: number;
+  transfersStored: number;
+  duplicatesSkipped: number;
+}
+
+export class BaseChainWatcher extends EventEmitter {
+  private connectionManager: ConnectionManager;
+  private merchantAddresses: Set<string>;
+  private transactionStore: TransactionStore | null;
+  private stats: BaseChainWatcherStats;
+  private isRunning: boolean = false;
+
+  constructor(config: BaseChainWatcherConfig) {
+    super();
+
+    this.merchantAddresses = new Set(config.merchantAddresses.map((addr) => addr.toLowerCase()));
+
+    this.transactionStore = config.transactionStore ?? null;
+
+    this.stats = {
+      transfersDetected: 0,
+      transfersFiltered: 0,
+      transfersStored: 0,
+      duplicatesSkipped: 0,
+    };
+
+    const connectionConfig: ConnectionManagerConfig = {
+      httpUrl: config.httpUrl,
+      wsUrl: config.wsUrl,
+      contractAddress: USDC_CONTRACTS.base,
+    };
+
+    this.connectionManager = new ConnectionManager(connectionConfig);
+    this.connectionManager.on('transfer', (log: TransferLog) => this.handleTransfer(log));
+    this.connectionManager.on('modeChange', (mode: string) => {
+      console.info(`[BaseChainWatcher] Connection mode changed to: ${mode}`);
+    });
+  }
+
+  get merchantAddressCount(): number {
+    return this.merchantAddresses.size;
+  }
+
+  get statistics(): BaseChainWatcherStats {
+    return { ...this.stats };
+  }
+
+  get connectionMode(): string {
+    return this.connectionManager.mode;
+  }
+
+  addMerchantAddress(address: string): void {
+    this.merchantAddresses.add(address.toLowerCase());
+  }
+
+  removeMerchantAddress(address: string): void {
+    this.merchantAddresses.delete(address.toLowerCase());
+  }
+
+  hasMerchantAddress(address: string): boolean {
+    return this.merchantAddresses.has(address.toLowerCase());
+  }
+
+  async start(): Promise<void> {
+    if (this.isRunning) {
+      return;
+    }
+
+    this.isRunning = true;
+    console.info(
+      `[BaseChainWatcher] Starting with ${this.merchantAddresses.size} merchant address(es)`,
+    );
+    console.info(`[BaseChainWatcher] Monitoring USDC contract: ${USDC_CONTRACTS.base}`);
+
+    await this.connectionManager.start();
+  }
+
+  stop(): void {
+    this.isRunning = false;
+    this.connectionManager.stop();
+    console.info('[BaseChainWatcher] Stopped');
+  }
+
+  private async handleTransfer(log: TransferLog): Promise<void> {
+    this.stats.transfersDetected++;
+
+    const toAddress = log.to.toLowerCase();
+
+    if (!this.merchantAddresses.has(toAddress)) {
+      this.stats.transfersFiltered++;
+      return;
+    }
+
+    console.info(
+      `[BaseChainWatcher] Merchant transfer detected: ${log.transactionHash} ` +
+        `(${this.parseAmount(log.value)} USDC to ${log.to})`,
+    );
+
+    this.emit('merchantTransfer', log);
+
+    if (this.transactionStore) {
+      await this.storeTransaction(log);
+    }
+  }
+
+  private async storeTransaction(log: TransferLog): Promise<void> {
+    if (!this.transactionStore) return;
+
+    const exists = await this.transactionStore.transactionExists('base', log.transactionHash);
+    if (exists) {
+      this.stats.duplicatesSkipped++;
+      console.info(`[BaseChainWatcher] Duplicate transaction skipped: ${log.transactionHash}`);
+      return;
+    }
+
+    const tx: InsertableTransaction = {
+      chain: 'base',
+      tx_hash: log.transactionHash,
+      block_number: log.blockNumber,
+      block_hash: log.blockHash,
+      sender_address: log.from.toLowerCase(),
+      receiver_address: log.to.toLowerCase(),
+      token_contract: USDC_CONTRACTS.base.toLowerCase(),
+      token_amount: this.parseRawAmount(log.value),
+    };
+
+    try {
+      await this.transactionStore.insertTransaction(tx);
+      this.stats.transfersStored++;
+      console.info(`[BaseChainWatcher] Transaction stored: ${log.transactionHash}`);
+      this.emit('transactionStored', tx);
+    } catch (error) {
+      console.error(`[BaseChainWatcher] Failed to store transaction:`, error);
+      this.emit('storeError', { log, error });
+    }
+  }
+
+  private parseRawAmount(hexValue: string): string {
+    const value = BigInt(hexValue);
+    return value.toString();
+  }
+
+  private parseAmount(hexValue: string): string {
+    const value = BigInt(hexValue);
+    const decimals = 6;
+    const divisor = BigInt(10 ** decimals);
+    const integerPart = value / divisor;
+    const fractionalPart = value % divisor;
+    const paddedFractional = fractionalPart.toString().padStart(decimals, '0');
+    return `${integerPart}.${paddedFractional}`;
+  }
+}

--- a/services/chain-watcher/src/index.ts
+++ b/services/chain-watcher/src/index.ts
@@ -1,51 +1,68 @@
-import { REDIS_STREAMS, USDC_CONTRACTS, RpcProviderConfig } from '@stripeonchain/shared';
-import { RpcHealthManager } from './rpc-health-manager';
+import { REDIS_STREAMS, USDC_CONTRACTS } from '@stripeonchain/shared';
+import { BaseChainWatcher } from './base-chain-watcher';
+import { PostgresTransactionStore } from './transaction-store';
 
 const SERVICE_NAME = 'chain-watcher';
 
-function getRpcConfigs(): RpcProviderConfig[] {
-  const primary = process.env.RPC_URL_PRIMARY;
-  const secondary = process.env.RPC_URL_SECONDARY;
-
-  const configs: RpcProviderConfig[] = [];
-
-  if (primary) {
-    configs.push({
-      url: primary,
-      name: 'primary',
-      priority: 1,
-    });
+function getMerchantAddresses(): string[] {
+  const addresses = process.env.MERCHANT_ADDRESSES;
+  if (!addresses) {
+    return [];
   }
-
-  if (secondary) {
-    configs.push({
-      url: secondary,
-      name: 'secondary',
-      priority: 2,
-    });
-  }
-
-  if (configs.length === 0) {
-    throw new Error('At least RPC_URL_PRIMARY must be configured');
-  }
-
-  return configs;
+  return addresses
+    .split(',')
+    .map((addr) => addr.trim())
+    .filter((addr) => addr.length > 0);
 }
 
 async function main() {
   console.info(`[${SERVICE_NAME}] Starting... (publishing to ${REDIS_STREAMS.CHAIN_TRANSACTIONS})`);
   console.info(`[${SERVICE_NAME}] Monitoring USDC contracts:`, USDC_CONTRACTS);
 
-  const rpcConfigs = getRpcConfigs();
-  const healthManager = new RpcHealthManager(rpcConfigs);
+  const httpUrl = process.env.BASE_RPC_URL;
+  const wsUrl = process.env.BASE_RPC_WS_URL;
+  const databaseUrl = process.env.DATABASE_URL;
 
-  console.info(`[${SERVICE_NAME}] Configured ${rpcConfigs.length} RPC provider(s)`);
+  if (!httpUrl || !wsUrl) {
+    throw new Error('BASE_RPC_URL and BASE_RPC_WS_URL must be configured');
+  }
 
-  await healthManager.start();
+  const merchantAddresses = getMerchantAddresses();
+  console.info(`[${SERVICE_NAME}] Configured ${merchantAddresses.length} merchant address(es)`);
 
-  const shutdown = () => {
+  let transactionStore: PostgresTransactionStore | undefined;
+  if (databaseUrl) {
+    transactionStore = new PostgresTransactionStore(databaseUrl);
+    console.info(`[${SERVICE_NAME}] Database connection configured`);
+  } else {
+    console.warn(
+      `[${SERVICE_NAME}] No DATABASE_URL configured, transactions will not be persisted`,
+    );
+  }
+
+  const watcher = new BaseChainWatcher({
+    httpUrl,
+    wsUrl,
+    merchantAddresses,
+    transactionStore,
+  });
+
+  watcher.on('merchantTransfer', (log) => {
+    console.info(`[${SERVICE_NAME}] Merchant transfer: ${log.transactionHash}`);
+  });
+
+  watcher.on('transactionStored', (tx) => {
+    console.info(`[${SERVICE_NAME}] Transaction stored: ${tx.tx_hash}`);
+  });
+
+  await watcher.start();
+
+  const shutdown = async () => {
     console.info(`[${SERVICE_NAME}] Shutting down...`);
-    healthManager.stop();
+    watcher.stop();
+    if (transactionStore) {
+      await transactionStore.close();
+    }
     process.exit(0);
   };
 

--- a/services/chain-watcher/src/transaction-store.ts
+++ b/services/chain-watcher/src/transaction-store.ts
@@ -1,0 +1,125 @@
+import { Pool } from 'pg';
+import { ChainTransaction, SupportedChain } from '@stripeonchain/shared';
+
+export interface InsertableTransaction {
+  chain: SupportedChain;
+  tx_hash: string;
+  block_number: number;
+  block_hash: string;
+  sender_address: string;
+  receiver_address: string;
+  token_contract: string;
+  token_amount: string;
+}
+
+export interface TransactionStore {
+  insertTransaction(tx: InsertableTransaction): Promise<void>;
+  transactionExists(chain: SupportedChain, txHash: string): Promise<boolean>;
+  close(): Promise<void>;
+}
+
+export class PostgresTransactionStore implements TransactionStore {
+  private pool: Pool;
+
+  constructor(connectionString: string) {
+    this.pool = new Pool({ connectionString });
+  }
+
+  async insertTransaction(tx: InsertableTransaction): Promise<void> {
+    const query = `
+      INSERT INTO chain_transactions (
+        chain, tx_hash, block_number, block_hash,
+        sender_address, receiver_address, token_contract, token_amount,
+        receipt
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+      ON CONFLICT (chain, tx_hash) DO NOTHING
+    `;
+
+    await this.pool.query(query, [
+      tx.chain,
+      tx.tx_hash,
+      tx.block_number,
+      tx.block_hash,
+      tx.sender_address,
+      tx.receiver_address,
+      tx.token_contract,
+      tx.token_amount,
+      JSON.stringify({}),
+    ]);
+  }
+
+  async transactionExists(chain: SupportedChain, txHash: string): Promise<boolean> {
+    const result = await this.pool.query(
+      'SELECT 1 FROM chain_transactions WHERE chain = $1 AND tx_hash = $2',
+      [chain, txHash],
+    );
+    return result.rowCount !== null && result.rowCount > 0;
+  }
+
+  async getTransaction(chain: SupportedChain, txHash: string): Promise<ChainTransaction | null> {
+    const result = await this.pool.query(
+      `SELECT id, chain, tx_hash, block_number, block_hash,
+              sender_address, receiver_address, token_contract, token_amount,
+              confirmation_count, finality_status, receipt, detected_at, finalized_at
+       FROM chain_transactions WHERE chain = $1 AND tx_hash = $2`,
+      [chain, txHash],
+    );
+
+    if (result.rowCount === 0) {
+      return null;
+    }
+
+    const row = result.rows[0];
+    return {
+      id: row.id,
+      chain: row.chain,
+      tx_hash: row.tx_hash,
+      block_number: row.block_number,
+      block_hash: row.block_hash,
+      sender_address: row.sender_address,
+      receiver_address: row.receiver_address,
+      token_contract: row.token_contract,
+      token_amount: row.token_amount,
+      confirmation_count: row.confirmation_count,
+      finality_status: row.finality_status,
+      receipt: row.receipt,
+      detected_at: row.detected_at,
+      finalized_at: row.finalized_at,
+    };
+  }
+
+  async close(): Promise<void> {
+    await this.pool.end();
+  }
+}
+
+export class InMemoryTransactionStore implements TransactionStore {
+  private transactions: Map<string, InsertableTransaction> = new Map();
+
+  private makeKey(chain: SupportedChain, txHash: string): string {
+    return `${chain}:${txHash}`;
+  }
+
+  async insertTransaction(tx: InsertableTransaction): Promise<void> {
+    const key = this.makeKey(tx.chain, tx.tx_hash);
+    if (!this.transactions.has(key)) {
+      this.transactions.set(key, tx);
+    }
+  }
+
+  async transactionExists(chain: SupportedChain, txHash: string): Promise<boolean> {
+    return this.transactions.has(this.makeKey(chain, txHash));
+  }
+
+  getAll(): InsertableTransaction[] {
+    return Array.from(this.transactions.values());
+  }
+
+  clear(): void {
+    this.transactions.clear();
+  }
+
+  async close(): Promise<void> {
+    this.transactions.clear();
+  }
+}


### PR DESCRIPTION
## Summary

Add BaseChainWatcher that subscribes to ERC-20 Transfer events on the Base USDC contract via WebSocket, filtering for transfers to configured merchant deposit addresses.

## Changes

- `BaseChainWatcher` class with WebSocket subscription to Transfer events via `ConnectionManager`
- `TransactionStore` interface with PostgreSQL and in-memory implementations
- Filter transfers by destination address (merchant deposit addresses from config)
- Parse transfer amount (6 decimals), sender, receiver, tx hash, block number
- Store discovered transactions in `chain_transactions` table
- Skip duplicate `tx_hash` insertions (idempotent)
- Updated `index.ts` to use `BaseChainWatcher` with environment configuration

## How to Test

1. `npm ci`
2. `npm run typecheck`
3. `npm test`

For manual testing with real Base network:
```bash
export BASE_RPC_URL="https://mainnet.base.org"
export BASE_RPC_WS_URL="wss://mainnet.base.org"
export MERCHANT_ADDRESSES="0x..."
export DATABASE_URL="postgres://..."
npm run dev --workspace=@stripeonchain/chain-watcher
```

## Tests

- [x] Tests added/updated
- [x] All tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Type-check passes (`npm run typecheck`)
- [x] Formatting passes (`npm run format:check`)

## Checklist

- [x] No secrets or credentials committed
- [x] Migrations run cleanly up and down (`npm run migrate:up` / `npm run migrate:down`)
- [x] Docker Compose starts without errors (`docker compose up`)

## Related Issues

Closes #13

Made with [Cursor](https://cursor.com)